### PR TITLE
Add poryseer.py for use as porygit (or jitro) module

### DIFF
--- a/SEENBOT.py
+++ b/SEENBOT.py
@@ -2,10 +2,11 @@ import time
 import datetime
 import json
 import os.path
+import sys
 
 class DATA_CELL(object):
     def __init__(self, nick, timestamp):
-        print "added new nick: " + nick
+        sys.stderr.write("added new nick: " + nick + '\n')
         self.current_nick = nick
         self.nick_history = []
         self.recent_timestamp = timestamp
@@ -42,7 +43,7 @@ class SEENBOT(object):
 
     def process(self, raw, botnick): # please do remove anything in front of the 'nick!name@hostmask' part of the raw
         data = raw.lower().split()
-        print data
+        sys.stderr.write(str(data) + '\n')
         nick = data[0].strip(':').split('!')[0]
         timestamp = time.time()
         timestamp = datetime.datetime.fromtimestamp(timestamp).strftime('%d/%m/%Y %H:%M:%S')

--- a/poryseer.py
+++ b/poryseer.py
@@ -5,9 +5,10 @@ import SEENBOT
 
 #### CONFIG ####
 config = {}
-config["nick"] = "SolSeer"
+config["network"] = "esper"
+config["nick"] = "porygit"
 config["channel"] = "#3dpe"
-config["debug"] = False
+config["debug"] = True
 
 def debug(text):
     if config["debug"]:
@@ -17,12 +18,14 @@ seenBot = SEENBOT.SEENBOT() # initialize the bot
 
 for line in iter(sys.stdin.readline, b''):
 # strip network name
-    line = ' '.join(line.split(' ')[1:])
+    line = ' '.join(line[:-1].split(' ')[1:])
 
     if ("PRIVMSG" in line) or ("NICK" in line):
-        console = "\n-X- ATTENTION -X- " + line + "\n"
+        debug(config["nick"] + " in: " + line)
         seen = seenBot.process(line, config["nick"])
         if seen != None:
-            print "esper PRIVMSG " + config["channel"] + " :" + seen
-        debug(console)
+            ircMessage = config["network"] + " PRIVMSG " + config["channel"] + " :" + seen
+            debug(config["nick"] + " out: " + ircMessage)
+            print ircMessage
+            sys.stdout.flush()
 

--- a/poryseer.py
+++ b/poryseer.py
@@ -11,11 +11,9 @@ config["debug"] = False
 
 def debug(text):
     if config["debug"]:
-        sys.stderr.wirte(text + '\n')
+        sys.stderr.write(text + '\n')
 
 seenBot = SEENBOT.SEENBOT() # initialize the bot
-
-debug("connecting")
 
 for line in iter(sys.stdin.readline, b''):
 # strip network name

--- a/poryseer.py
+++ b/poryseer.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python2
+import sys
+import SEENBOT
+
+
+#### CONFIG ####
+config = {}
+config["nick"] = "SolSeer"
+config["channel"] = "#3dpe"
+config["debug"] = False
+
+def debug(text):
+    if config["debug"]:
+        print text
+
+seenBot = SEENBOT.SEENBOT() # initialize the bot
+
+debug("connecting")
+
+for line in iter(sys.stdin.readline, b''):
+# strip network name
+    line = ' '.join(line.split(' ')[1:])
+
+    if ("PRIVMSG" in line) or ("NICK" in line):
+        console = "\n-X- ATTENTION -X- " + line + "\n"
+        seen = seenBot.process(line, config["nick"])
+        if seen != None:
+            print "esper PRIVMSG " + config["channel"] + " :" + seen
+        debug(console)
+

--- a/poryseer.py
+++ b/poryseer.py
@@ -11,7 +11,7 @@ config["debug"] = False
 
 def debug(text):
     if config["debug"]:
-        print text
+        sys.stderr.wirte(text + '\n')
 
 seenBot = SEENBOT.SEENBOT() # initialize the bot
 

--- a/tests/test0
+++ b/tests/test0
@@ -1,0 +1,1 @@
+esper :abc PRIVMSG #3dpe :!seen jac

--- a/tests/test1
+++ b/tests/test1
@@ -1,0 +1,2 @@
+esper :jac PRIVMSG #3dpe :hi
+esper :abc PRIVMSG #3dpe :!seen jac

--- a/tests/test2
+++ b/tests/test2
@@ -1,0 +1,3 @@
+esper :jac PRIVMSG #3dpe :hi
+esper :jac NICK jac2
+esper :abc PRIVMSG #3dpe :!seen jac


### PR DESCRIPTION
Alright, so the first thing this has is a new file `poryseer.py` which allows it to be used in a `stdin`/`stdout` fashion. Any debugging info is printed to `stderr` to not screw any of that up. I've added the `tests/` directory which is useful for testing any changes to `SEENBOT`, like this:

```
    cat tests/test1 | ./poryseer.py
```

If you look at the individual test files, they should be self explanatory.

The meat and potato change is that `SEENBOT` automatically serializes itself to json and saves itself as a file every time `self.database` changes in `process`. When a `SEENBOT` is created, it also tries to automatically load itself. This code is not the best, honestly.
